### PR TITLE
Compatibility with NumPy 2.0

### DIFF
--- a/src/iranges/IRanges.py
+++ b/src/iranges/IRanges.py
@@ -118,13 +118,13 @@ class IRanges:
         if isinstance(start, np.ndarray) and start.dtype == np.int32:
             return start
 
-        return np.array(start, dtype=np.int32, copy=False)
+        return np.asarray(start, dtype=np.int32)
 
     def _sanitize_width(self, width):
         if isinstance(width, np.ndarray) and width.dtype == np.int32:
             return width
 
-        return np.array(width, dtype=np.int32, copy=False)
+        return np.asarray(width, dtype=np.int32)
 
     def _validate_width(self):
         if len(self._start) != len(self._width):


### PR DESCRIPTION
Notes from NumPy 2.0 release:

> If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
> For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.