### PR TITLE
Improved worksharing across threads for find_overlaps_groups.

### DIFF
--- a/lib/src/nclsoverlaps.cpp
+++ b/lib/src/nclsoverlaps.cpp
@@ -215,7 +215,7 @@ pybind11::tuple perform_find_overlaps_groups(
         }
     }
 
-    // Now running through all groups to find overlaps in parallel. 
+    // Now running through all groups to find overlaps in parallel.
     std::vector<std::vector<std::vector<Index> > > all_group_results(n_groups);
     std::vector<std::thread> workers;
     workers.reserve(num_threads);
@@ -292,7 +292,7 @@ pybind11::tuple perform_find_overlaps_groups(
                     current_total_hits += single_query_matches.size();
                 }
 
-                // Don't add directly to this value in the inner loop, to reduce the risk of false sharing. 
+                // Don't add directly to this value in the inner loop, to reduce the risk of false sharing.
                 total_hits_per_thread[thread] += current_total_hits;
             }, i, jobs_so_far, current_jobs);
 


### PR DESCRIPTION
The idea is to ensure that all threads are occupied, even when the groups are of different sizes. This is done with some more fine-grained parallelization during both index building and overlap identification.